### PR TITLE
Fix sql queries

### DIFF
--- a/internal/storage/subscription.go
+++ b/internal/storage/subscription.go
@@ -187,8 +187,7 @@ func (s *PostgresSubscriptionStorage) TotalForPeriod(
 	sb.Select("start_date", "end_date", "price").
 		From("subscriptions").
 		Where(sb.LessEqualThan("start_date", peEnd)).
-		Where(sb.Or(sb.IsNull("end_date"), sb.GreaterEqualThan("end_date", periodStart))).
-		Desc()
+		Where(sb.Or(sb.IsNull("end_date"), sb.GreaterEqualThan("end_date", periodStart)))
 
 	if userID != uuid.Nil {
 		sb.Where(sb.Equal("user_id", userID.String()))
@@ -209,7 +208,7 @@ func (s *PostgresSubscriptionStorage) TotalForPeriod(
 	var total int64
 	for rows.Next() {
 		var sub models.Subscription
-		if err := rows.Scan(&sub.ID, &sub.ServiceName, &sub.Price, &sub.UserID, &sub.StartDate, &sub.EndDate); err != nil {
+		if err := rows.Scan(&sub.StartDate, &sub.EndDate, &sub.Price); err != nil {
 			return 0, err
 		}
 


### PR DESCRIPTION
Remove invalid `Desc()` call and align `rows.Scan` with selected columns in `TotalForPeriod` to fix SQL.

---
<a href="https://cursor.com/background-agent?bcId=bc-a15672c7-4637-43f6-8f44-5fc51eb5190e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a15672c7-4637-43f6-8f44-5fc51eb5190e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

